### PR TITLE
i18n.setLocale should return a promise anytime.

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -41,13 +41,12 @@ export const i18n = {
                 promise = i18n.loadLocale(i18n._locale, options);
             }
             if (!silent) {
-                promise.then(() => {
+                promise = promise.then(() => {
                     i18n._emitChange();
                 });
             }
-            promise.catch(console.error.bind(console));
-            promise.then(() => i18n._isLoaded[i18n._locale] = true);
-            return promise;
+            return promise.catch(console.error.bind(console))
+              .then(() => i18n._isLoaded[i18n._locale] = true);
         }
         if (!silent) {
           i18n._emitChange();

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -27,7 +27,7 @@ export const i18n = {
         i18n._locale = i18n.normalize(locale);
         if (!i18n._locale) {
             console.error('Wrong locale:', locale, '[Should be xx-yy or xx]');
-            return;
+            return Promise.reject(new Error('Wrong locale: ' + locale + ' [Should be xx-yy or xx]'));
         }
         const {noDownload = false, silent = false} = options;
         if (Meteor.isClient && !noDownload) {
@@ -49,10 +49,10 @@ export const i18n = {
             promise.then(() => i18n._isLoaded[i18n._locale] = true);
             return promise;
         }
-        if (silent) {
-            return;
+        if (!silent) {
+          i18n._emitChange();
         }
-        i18n._emitChange();
+        return Promise.resolve();
     },
     /**
      * @param {string} locale


### PR DESCRIPTION
i18n.setLocale returned nothing when an error occurs. It might crash `i18n.setLocale(some_locale).then(some_func);` because of calling `then` method of `undefined`.
I think a rejected promise object should be returned in this case.

From discussions in http://stackoverflow.com/questions/32216619/is-there-a-difference-between-promise-then-then-vs-promise-then-promise-then, promise objects should be chained, too.