### PR TITLE
Providing custom DOM element type and props to the element

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ const T = i18n.createComponent(i18n.createTranslator('common'));
 <T>ok</T>
 // this time with override locale
 <T _locale='pl-PL'>hello</T>
+// overriding the default DOM element 'span' with 'h1'
+<T tagType='h1'>hello</T>
 ```
 
 ### Refresh mixin

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ const T = i18n.createComponent(i18n.createTranslator('common'));
 <T _locale='pl-PL'>hello</T>
 // overriding the default DOM element 'span' with 'h1'
 <T tagType='h1'>hello</T>
+// providing props to the element
+<T props={{ className: 'text-center', style: { color: '#f33' }}}>hello</T>
 ```
 
 ### Refresh mixin

--- a/README.md
+++ b/README.md
@@ -382,13 +382,14 @@ Meteor.methods({
 ## API
 ```js
 // create React component
-i18n.createComponent(translator, locale, reactjs);
+i18n.createComponent(translator, locale, reactjs, type);
 //  @params:
 //    translator - (optional, default is i18n.createTranslator())
 //      using this argument you can set different function for translation or the namespace for default translator.
 //    locale - (optional, default current locale) set language for this component (can be different than on rest of site)
 //    reactjs - (optional, as a default it tries to get React from global variable)
 //      you can pass React object if is not available in global scope
+//    type - (optional, as default it uses <span> to render the content.) set which DOM element that will be rendered, e.g. 'li', 'div' or 'h1'.
 
 // create namespaced translator
 i18n.createTranslator(namespace, locale);

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -99,11 +99,13 @@ export const i18n = {
             };
 
             render() {
-                const {children, tagType, ...params} = this.props;
+                const {children, tagType, props= {}, ...params} = this.props;
                 return reactjs.createElement(tagType || type || 'span', {
                     dangerouslySetInnerHTML: {
                         __html: translator(children, params)
-                    }, key: this.state.systemlocale
+                    },
+                    key: this.state.systemlocale,
+                    ..._.omit(props, [ 'dangerouslySetInnerHTML', 'key' ])
                 });
             }
 

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -99,8 +99,8 @@ export const i18n = {
             };
 
             render() {
-                let {children, ...params} = this.props;
-                return reactjs.createElement(type, {
+                const {children, tagType, ...params} = this.props;
+                return reactjs.createElement(tagType || type || 'span', {
                     dangerouslySetInnerHTML: {
                         __html: translator(children, params)
                     }, key: this.state.systemlocale

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -69,7 +69,7 @@ export const i18n = {
     getLocale () {
         return contextualLocale.get() || i18n._locale || i18n._defaultLocale;
     },
-    createComponent (translator = i18n.createTranslator(), locale, reactjs) {
+    createComponent (translator = i18n.createTranslator(), locale, reactjs, type) {
         if (typeof translator === 'string') {
             translator = i18n.createTranslator(translator, locale);
         }
@@ -100,7 +100,7 @@ export const i18n = {
 
             render() {
                 let {children, ...params} = this.props;
-                return reactjs.createElement('span', {
+                return reactjs.createElement(type, {
                     dangerouslySetInnerHTML: {
                         __html: translator(children, params)
                     }, key: this.state.systemlocale

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -101,11 +101,10 @@ export const i18n = {
             render() {
                 const {children, tagType, props= {}, ...params} = this.props;
                 return reactjs.createElement(tagType || type || 'span', {
+                    ...props,
                     dangerouslySetInnerHTML: {
                         __html: translator(children, params)
-                    },
-                    key: this.state.systemlocale,
-                    ..._.omit(props, [ 'dangerouslySetInnerHTML', 'key' ])
+                    }, key: this.state.systemlocale
                 });
             }
 

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -99,9 +99,9 @@ export const i18n = {
             };
 
             render() {
-                const {children, tagType, props= {}, ...params} = this.props;
-                return reactjs.createElement(tagType || type || 'span', {
-                    ...props,
+                const {children, _tagType, _props = {}, ...params} = this.props;
+                return reactjs.createElement(_tagType || type || 'span', {
+                    ..._props,
                     dangerouslySetInnerHTML: {
                         __html: translator(children, params)
                     }, key: this.state.systemlocale


### PR DESCRIPTION
This PR does three things:
- Adds option to alter which DOM element type should be rendered by the component wile creating the component with `i18n.createComponent`.
- Adds option to override the default / specified DOM element type by providing a prop called `tagType` to the component. Usage: `<T tagType='li'>hello</T>`.
- Provides props down to the returned component using a property called `props`. Usage: `<T props={{ className: 'text-center', style: { color: '#f33' }}}>hello</T>`.