### PR TITLE
Fixing header content containing invalid characters

### DIFF
--- a/server/api.js
+++ b/server/api.js
@@ -10,7 +10,7 @@ i18n.getCache = function getCache(locale){
     if (locale){
         if (!cache[locale]) {
             cache[locale] = {
-                updatedAt: new Date(),
+                updatedAt: new Date().toUTCString(),
                 getYML,
                 getJSON,
                 getJS


### PR DESCRIPTION
The issue was because I was using a french computer in New Zealand.

Here is the header string that failed:
`{ 'Last-Modified': Fri Mar 10 2017 14:23:43 GMT+1300 (Nouvelle-Zélande (heure d’été)) }`

As you can see there are accents.
I fixed it by using new Date().toUTCString() as you can see in the commit.