### PR TITLE
Fixed handling of separators in keys.

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -222,23 +222,22 @@ export const i18n = {
         }
         return get(i18n._translations, namespace, {});
     },
-    addTranslation (locale, ...args) {
-        let translation = args.pop();
-        let namespace = args.length && args.join('.');
-        namespace = namespace && namespace.replace(/(\.\.)|(\.$)/, '');
+    addTranslation (locale, ...args /*, translation */) {
+        const translation = args.pop();
+        const path = args.join('.').replace(/(\.\.)|(\.$)/g, '');
+
         locale = locale.toLowerCase().replace('_', '-');
         if (LOCALES[locale]) {
             locale = LOCALES[locale][0];
         }
-        namespace = _.compact([locale, namespace]).join('.');
-        if (typeof translation !== 'string') {
-            translation = deepExtend(
-                get(i18n._translations, namespace) || {},
-                translation
-            );
+
+        if (typeof translation === 'string') {
+            set(i18n._translations, [locale, path].join('.'), translation);
+        } else if (translation === Object(translation)) {
+            Object.keys(translation).sort().forEach(key => i18n.addTranslation(locale, path, key, translation[key]));
         }
 
-        return set(i18n._translations, namespace, translation);
+        return i18n._translations;
     },
     /**
      * parseNumber('7013217.715'); // 7,013,217.715


### PR DESCRIPTION
### Current behaviour

```js
i18n.addTranslation('en', {'a.b': '1', 'a.c': '2'});
i18n._translations.en.a; // undefined
i18n._translations.en['a.b']; // '1'
i18n._translations.en['a.c']; // '2'
```

### With this change

```js
i18n.addTranslation('en', {'a.b': '1', 'a.c': '2'});
i18n._translations.en.a.b; // '1'
i18n._translations.en.a.c; // '2'
i18n._translations.en['a.b']; // undefined
i18n._translations.en['a.c']; // undefined
```

### Motivation

```js
i18n.addTranslation('en', {'a.b': '1'});
i18n.getTranslation('a.b'); // ''
```