### PR TITLE
remove leftover underscore import

### DIFF
--- a/server/syncServerWithClient.js
+++ b/server/syncServerWithClient.js
@@ -1,5 +1,4 @@
 import i18n from '../lib/i18n';
-import {_} from 'meteor/underscore';
 import {Meteor} from 'meteor/meteor';
 import {check, Match} from 'meteor/check';
 import {DDP} from 'meteor/ddp';


### PR DESCRIPTION
leftover from #106

when trying to publish a fork to workaround #107 we realized there was a leftover import.