### PR TITLE
Fixed path analysis (fixes #132, closes #134).

### DIFF
--- a/package.js
+++ b/package.js
@@ -54,11 +54,15 @@ Package.onTest(function (api) {
   ]);
 
   api.addFiles([
-    'tests/common.ts',
+    'tests/data/de/ch.i18n.yml',
+    'tests/data/en_gb.i18n.json',
     'tests/data/es-es.i18n.json',
-    'tests/data/fr-fr.i18n.yml',
+    'tests/data/fr.i18n.yml',
     'tests/data/it-it.i18n.yml',
+    'tests/data/nest/el/y.i18n.yml',
+    'tests/data/pl-pl/x.i18n.yml',
+    'tests/data/z.i18n.yml',
   ]);
-  api.addFiles(['tests/client.ts'], 'client');
-  api.addFiles(['tests/server.ts'], 'server');
+  api.addFiles(['tests/client.ts', 'tests/common.ts'], 'client');
+  api.addFiles(['tests/server.ts', 'tests/common.ts'], 'server');
 });

--- a/source/common.ts
+++ b/source/common.ts
@@ -90,8 +90,8 @@ const i18n = {
       const parts = locale.toLowerCase().split(/[-_]/);
       while (parts.length) {
         const locale = parts.join('-');
-        if (locale in LOCALES) {
-          locales.push(LOCALES[locale][0]);
+        if (locale in i18n._locales) {
+          locales.push(i18n._locales[locale][0]);
         }
 
         parts.pop();
@@ -247,8 +247,8 @@ const i18n = {
       if (typeof args[finalArg] === 'object') {
         _namespace = args[finalArg]._namespace || _namespace;
         args[finalArg] = { ...finalOptions, ...args[finalArg] };
-      } else if (options) {
-        args.push(options);
+      } else if (finalOptions) {
+        args.push(finalOptions);
       }
 
       if (_namespace) {

--- a/tests/client.ts
+++ b/tests/client.ts
@@ -2,16 +2,20 @@ import { i18n } from 'meteor/universe:i18n';
 
 describe('universe-i18n - client', () => {
   it('should load translations incrementally', async () => {
-    expect(i18n.isLoaded('it-IT')).to.not.be.true;
-    await i18n.setLocale('it-IT');
-    expect(i18n.isLoaded('it-IT')).to.be.true;
-    expect(i18n.getLocale()).to.equal('it-IT');
+    const locale = 'it-IT';
+    expect(i18n.isLoaded(locale)).to.not.be.true;
+    await i18n.setLocale(locale);
+    expect(i18n.isLoaded(locale)).to.be.true;
+    expect(i18n.getLocale()).to.equal(locale);
+    expect(i18n.getLanguages()).to.include(locale);
   });
 
   it('should list only available languages', async () => {
-    expect(i18n.isLoaded('zh-CN')).to.not.be.true;
-    await i18n.setLocale('zh-CN');
-    expect(i18n.isLoaded('zh-CN')).to.be.true;
-    expect(i18n.getLanguages()).to.not.include(i18n.getLocale());
+    const locale = 'zh-CN';
+    expect(i18n.isLoaded(locale)).to.not.be.true;
+    await i18n.setLocale(locale);
+    expect(i18n.isLoaded(locale)).to.be.true;
+    expect(i18n.getLocale()).to.equal(locale);
+    expect(i18n.getLanguages()).to.not.include(locale);
   });
 });

--- a/tests/common.ts
+++ b/tests/common.ts
@@ -8,7 +8,25 @@ describe('universe-i18n', () => {
 
   it('should support JSON files', async () => {
     await i18n.setLocale('es-ES');
-    expect(i18n.__('common.name')).to.equal('json-es');
+    expect(i18n.__('common.name')).to.equal('json-es-es');
+  });
+
+  it('should support all kinds of translations files', async () => {
+    const cases = [
+      ['de-CH', 'yml-de-ch'],
+      ['el', 'yml-el'],
+      ['en-GB', 'json-en-gb'],
+      ['es-ES', 'json-es-es'],
+      ['fr', 'yml-fr'],
+      ['it-IT', 'yml-it-it'],
+      ['pl-PL', 'yml-pl-pl'],
+      ['tr', 'yml-tr'],
+    ];
+
+    for (const [locale, name] of cases) {
+      await i18n.setLocale(locale);
+      expect(i18n.__('common.name')).to.equal(name);
+    }
   });
 
   it('should be able to set locale', async () => {
@@ -91,14 +109,14 @@ describe('universe-i18n', () => {
   it('should be able to create translators', async () => {
     const frenchTranslator = i18n.createTranslator('', 'fr-FR');
     await i18n.setLocale('es-ES');
-    expect(i18n.__('common.name')).to.equal('json-es');
+    expect(i18n.__('common.name')).to.equal('json-es-es');
     expect(frenchTranslator('common.name')).to.equal('yml-fr');
   });
 
   it('should be able to create reactive translators', async () => {
     const frenchReactiveTranslator = i18n.createReactiveTranslator('', 'fr-FR');
     await i18n.setLocale('es-ES');
-    expect(i18n.__('common.name')).to.equal('json-es');
+    expect(i18n.__('common.name')).to.equal('json-es-es');
     expect(frenchReactiveTranslator('common.name')).to.equal('yml-fr');
   });
 

--- a/tests/data/de/ch.i18n.yml
+++ b/tests/data/de/ch.i18n.yml
@@ -1,0 +1,3 @@
+_namespace: ''
+common:
+    name: yml-de-ch

--- a/tests/data/en_gb.i18n.json
+++ b/tests/data/en_gb.i18n.json
@@ -1,6 +1,6 @@
 {
   "_namespace": "",
   "common": {
-    "name": "json-es-es"
+    "name": "json-en-gb"
   }
 }

--- a/tests/data/fr.i18n.yml
+++ b/tests/data/fr.i18n.yml
@@ -1,4 +1,3 @@
-_locale: 'fr-FR'
 _namespace: ''
 common:
     name: yml-fr

--- a/tests/data/it-it.i18n.yml
+++ b/tests/data/it-it.i18n.yml
@@ -1,4 +1,2 @@
-_locale: 'it-IT'
-_namespace: ''
-common:
-    name: yml-it
+_namespace: common
+name: yml-it-it

--- a/tests/data/nest/el/y.i18n.yml
+++ b/tests/data/nest/el/y.i18n.yml
@@ -1,0 +1,3 @@
+_namespace: ''
+common:
+    name: yml-el

--- a/tests/data/pl-pl/x.i18n.yml
+++ b/tests/data/pl-pl/x.i18n.yml
@@ -1,0 +1,3 @@
+_namespace: ''
+common:
+    name: yml-pl-pl

--- a/tests/data/z.i18n.yml
+++ b/tests/data/z.i18n.yml
@@ -1,0 +1,3 @@
+_locale: tr
+_namespace: common
+name: yml-tr


### PR DESCRIPTION
In this PR, I reworked the `analyzePath` function so it should work at least as good as the pre-TypeScript version, fixing #132 and closing #134.