### PR TITLE
Fix: Cached translations are not refreshing after update

### DIFF
--- a/source/compiler.ts
+++ b/source/compiler.ts
@@ -94,6 +94,7 @@ class UniverseI18nCompiler extends CachingCompiler {
         `'${options.namespace ?? packageName ?? ''}',`,
         JSON.stringify(content.data),
         ');',
+        `Package['universe:i18n'].i18n._ts = Math.max(Package['universe:i18n'].i18n._ts, ${Date.now()});`
       ].join(''),
     };
   }


### PR DESCRIPTION
Added missing timestamp of the translation file