### PR TITLE
Fixed locale data accesses (fixes #140).

### DIFF
--- a/source/common.ts
+++ b/source/common.ts
@@ -80,6 +80,10 @@ const i18n = {
     return Promise.resolve();
   },
   _locale: 'en',
+  _localeData(locale?: string) {
+    locale = i18n.normalize(locale ?? i18n.getLocale());
+    return locale && i18n._locales[locale.toLowerCase()];
+  },
   _locales: LOCALES,
   _logger(error: unknown) {
     console.error(error);
@@ -307,10 +311,10 @@ const i18n = {
     return SYMBOLS[code?.[0] || locale];
   },
   getLanguageName(locale?: string) {
-    return i18n._locales[i18n.normalize(locale ?? i18n.getLocale())!]?.[1];
+    return i18n._localeData(locale)?.[1];
   },
   getLanguageNativeName(locale?: string) {
-    return i18n._locales[i18n.normalize(locale ?? i18n.getLocale())!]?.[2];
+    return i18n._localeData(locale)?.[2];
   },
   getLanguages(type: 'code' | 'name' | 'nativeName' = 'code') {
     const codes = Object.keys(i18n._translations);
@@ -388,7 +392,7 @@ const i18n = {
     return i18n._isLoaded[locale ?? i18n.getLocale()];
   },
   isRTL(locale?: string) {
-    return i18n._locales[i18n.normalize(locale ?? i18n.getLocale())!]?.[3];
+    return i18n._localeData(locale)?.[3];
   },
   loadLocale(locale: string, options?: LoadLocaleOptions) {
     // Actual implementation is only on the client.

--- a/tests/common.ts
+++ b/tests/common.ts
@@ -80,6 +80,11 @@ describe('universe-i18n', () => {
     expect(i18n.parseNumber('7013217.715', 'ru-RU')).to.equal('7 013 217,715');
   });
 
+  it('should return correct locale data', () => {
+    expect(i18n.getLanguageNativeName('pt')).to.equal('Português');
+    expect(i18n.getLanguageNativeName('pt-BR')).to.equal('Português (Brasil)');
+  });
+
   it('should be able to get currency symbol and currency codes', () => {
     expect(i18n.getCurrencySymbol('en-US')).to.equal('$');
     expect(i18n.getCurrencySymbol('USD')).to.equal('$');


### PR DESCRIPTION
In this PR, I've added required `toLowerCase` calls, as said in https://github.com/vazco/meteor-universe-i18n/issues/140#issuecomment-964116058.