### PR TITLE
Fixed returning [object Object] instead of actual object

### DIFF
--- a/source/common.ts
+++ b/source/common.ts
@@ -370,6 +370,10 @@ const i18n = {
         ),
     );
 
+    if (typeof translation === 'object') {
+      return globalThis.JSON.stringify(translation);
+    }
+
     let string = translation ? `${translation}` : hideMissing ? '' : key;
     Object.entries(variables).forEach(([key, value]) => {
       const tag = open + key + close;


### PR DESCRIPTION
If a translation is an object, return it instead of parsing it to string.