### PR TITLE
Locale change verification

### DIFF
--- a/source/client.ts
+++ b/source/client.ts
@@ -106,5 +106,11 @@ if (typeof preloaded === 'object') {
   }
 });
 
+const originalSetLocale = i18n.setLocale;
+i18n.setLocale = (locale, options, shouldVerifyLocale = false) =>
+shouldVerifyLocale && i18n.getLocale() === i18n.normalize(locale)
+    ? Promise.resolve()
+    : originalSetLocale.call(i18n, locale, options);
+
 export { i18n };
 export default i18n;

--- a/source/client.ts
+++ b/source/client.ts
@@ -106,11 +106,5 @@ if (typeof preloaded === 'object') {
   }
 });
 
-const originalSetLocale = i18n.setLocale;
-i18n.setLocale = (locale, options, shouldVerifyLocale = false) =>
-shouldVerifyLocale && i18n.getLocale() === i18n.normalize(locale)
-    ? Promise.resolve()
-    : originalSetLocale.call(i18n, locale, options);
-
 export { i18n };
 export default i18n;

--- a/source/common.ts
+++ b/source/common.ts
@@ -42,12 +42,12 @@ export interface Options {
   defaultLocale: string;
   hideMissing: boolean;
   hostUrl: string;
+  ignoreNoopLocaleChanges: boolean;
   open: string;
   pathOnHost: string;
   purify: undefined | ((string: string) => string);
   sameLocaleOnServerConnection: boolean;
   translationsHeaders: Record<string, string>;
-  ignoreNoopLocaleChanges?: boolean;
 }
 
 export interface SetLocaleOptions extends LoadLocaleOptions {
@@ -416,6 +416,7 @@ const i18n = {
     defaultLocale: 'en',
     hideMissing: false,
     hostUrl: '/',
+    ignoreNoopLocaleChanges: false,
     open: '{$',
     pathOnHost: 'universe/locale/',
     purify: undefined,
@@ -447,8 +448,8 @@ const i18n = {
       return Promise.reject(message);
     }
 
-    if(i18n.options.ignoreNoopLocaleChanges && i18n.getLocale() === normalizedLocale){
-      return Promise.resolve()
+    if (i18n.options.ignoreNoopLocaleChanges && i18n.getLocale() === normalizedLocale) {
+      return Promise.resolve();
     }
 
     i18n._locale = normalizedLocale;

--- a/source/common.ts
+++ b/source/common.ts
@@ -47,6 +47,7 @@ export interface Options {
   purify: undefined | ((string: string) => string);
   sameLocaleOnServerConnection: boolean;
   translationsHeaders: Record<string, string>;
+  ignoreNoopLocaleChanges?: boolean;
 }
 
 export interface SetLocaleOptions extends LoadLocaleOptions {
@@ -444,6 +445,10 @@ const i18n = {
       const message = `Unrecognized locale "${locale}"`;
       i18n._logger(message);
       return Promise.reject(message);
+    }
+
+    if(i18n.options.ignoreNoopLocaleChanges && i18n.getLocale() === normalizedLocale){
+      return Promise.resolve()
     }
 
     i18n._locale = normalizedLocale;


### PR DESCRIPTION
Fixes #127

This PR allows to add optional argument to the `setLocale` function to call it only if the passed locale is different then the currently set one.