### PR TITLE
Fixed JSON type import

### DIFF
--- a/source/common.ts
+++ b/source/common.ts
@@ -2,7 +2,8 @@ import { EventEmitter } from 'events';
 import { Meteor } from 'meteor/meteor';
 import { Tracker } from 'meteor/tracker';
 
-import { JSON, JSONObject, get, isJSONObject, set } from './utils';
+import { get, isJSONObject, set } from './utils';
+import type { JSON, JSONObject } from './utils';
 
 export interface GetCacheEntry {
   getJS(locale: string, namespace?: string, isBefore?: boolean): string;

--- a/source/compiler.ts
+++ b/source/compiler.ts
@@ -7,7 +7,8 @@ import { extname } from 'path';
 import stripJsonComments from 'strip-json-comments';
 
 import { i18n } from './common';
-import { isJSONObject, set, JSON } from './utils';
+import { isJSONObject, set } from './utils';
+import type { JSON } from './utils';
 
 declare class Compiler {}
 declare class Plugin {


### PR DESCRIPTION
Previously JSON wasn't imported as type only, and it led to errors when global JSON was called (for example, `JSON.parse` and `JSON.stringify` in `compiler.ts`)

Importing translations from files doesn't work without this change. It was broken [here](https://github.com/vazco/meteor-universe-i18n/pull/167).

Additionally, I changed the `JSON` import in the `common.ts`. It doesn't change anything, but it is future-proof if we want to use global JSON in this file.