### PR TITLE
Add query parameters to avoid JSON warning

### DIFF
--- a/source/server.ts
+++ b/source/server.ts
@@ -163,7 +163,7 @@ i18n.loadLocale = async (
 
   const url = resolve(
     host,
-    pathOnHost + normalizedLocale + '?' + queryParams.type,
+    pathOnHost + normalizedLocale + '?type=' + queryParams.type,
   );
 
   try {


### PR DESCRIPTION
I keep having there errors : 
<img width="673" alt="Screenshot 2023-01-02 at 15 43 24" src="https://user-images.githubusercontent.com/2357779/210246387-073a10e0-21e9-4ed0-bf15-26a788996acc.png">

with more than 20 translations it is very annoying in dev

By adding `type=json`, I have no warning, #148 and #126 had this problem without any way to reproduce it

In postman result is text with `?json`

<img width="1301" alt="Screenshot 2023-01-02 at 15 40 15" src="https://user-images.githubusercontent.com/2357779/210246316-601feb55-f8ce-4465-b7fa-3399ec04e488.png">

whereas with `type=json`

<img width="1327" alt="Screenshot 2023-01-02 at 15 40 27" src="https://user-images.githubusercontent.com/2357779/210246303-61d296ad-f316-408c-93e0-7412a6beabfa.png">
