### PR TITLE
Minimum Meteor version support

### DIFF
--- a/package.js
+++ b/package.js
@@ -21,7 +21,7 @@ Package.registerBuildPlugin({
 });
 
 Package.onUse(function (api) {
-  api.versionsFrom('1.9');
+  api.versionsFrom('2.3');
   api.use([
     'check',
     'ddp',
@@ -29,7 +29,7 @@ Package.onUse(function (api) {
     'isobuild:compiler-plugin@1.0.0',
     'promise',
     'tracker',
-    'typescript@4.0.0 || 3.0.0',
+    'typescript',
     'webapp',
     'zodern:types@1.0.0',
   ]);


### PR DESCRIPTION
We support Meteor <2.3, but it uses Node 12. `meteor-universe-i18n` uses optional chaining and nullish coalescing that were introduced in Node 14.

Downgrading code to support Node 12 will downgrade the quality of code and the latest attempt to change it caused failed CI tests. Since this PR, the minimum supported version of Meteor will be `v2.3`.
