### PR TITLE
Enable meteor 3 compatibility by removing dependency to a specific version of caching-compiler

### DIFF
--- a/package.js
+++ b/package.js
@@ -15,7 +15,7 @@ const npmDependencies = {
 Npm.depends(npmDependencies);
 Package.registerBuildPlugin({
   name: 'universe:i18n',
-  use: ['caching-compiler@1.2.2', 'tracker', 'typescript'],
+  use: ['caching-compiler', 'tracker', 'typescript'],
   sources: [
     'source/common.ts',
     'source/compiler.ts',


### PR DESCRIPTION

Caching-compiler has been bumped to 2.0.0 within Meteor 3. This change allows to add the plugin and avoids encounter the following error : 
``` 
=> Errors while adding packages:             
                                              
While selecting package versions:
error: Conflict: Constraint caching-compiler@1.2.2 is not satisfied by caching-compiler 2.0.0-alpha300.18.
Constraints on package "caching-compiler":
* caching-compiler@~2.0.0-alpha300.18 <- top level
* caching-compiler@2.0.0-alpha300.17 <- caching-html-compiler 2.0.0-alpha300.17 <- static-html 1.3.3-alpha300.18
* caching-compiler@2.0.0-alpha300.17 <- coffeescript 2.7.0
* caching-compiler@1.2.2 <- universe:i18n 2.1.0
```


Tested with METEOR@3.0-alpha.18
