### PR TITLE
Enable meteor 3 compatibility by adding specific versions of caching-compiler

### DIFF
--- a/package.js
+++ b/package.js
@@ -15,7 +15,7 @@ const npmDependencies = {
 Npm.depends(npmDependencies);
 Package.registerBuildPlugin({
   name: 'universe:i18n',
-  use: ['caching-compiler@1.2.2', 'tracker', 'typescript'],
+  use: ['caching-compiler', 'tracker', 'typescript'],
   sources: [
     'source/common.ts',
     'source/compiler.ts',

--- a/package.js
+++ b/package.js
@@ -15,7 +15,7 @@ const npmDependencies = {
 Npm.depends(npmDependencies);
 Package.registerBuildPlugin({
   name: 'universe:i18n',
-  use: ['caching-compiler', 'tracker', 'typescript'],
+  use: ['caching-compiler@1.2.2 || 2.0.0-beta300.6 || 2.0.0', 'tracker', 'typescript'],
   sources: [
     'source/common.ts',
     'source/compiler.ts',
@@ -26,7 +26,7 @@ Package.registerBuildPlugin({
 });
 
 Package.onUse(function (api) {
-  api.versionsFrom('2.3');
+  api.versionsFrom(['2.3', '3.0-beta.6']);
   api.use([
     'check',
     'ddp',


### PR DESCRIPTION
Caching-compiler has been bumped to 2.0.0 within Meteor 3. This change allows to add the plugin and avoids encounter the following error :
```
=> Errors while adding packages:             
                                              
While selecting package versions:
error: Conflict: Constraint caching-compiler@1.2.2 is not satisfied by caching-compiler 2.0.0-alpha300.18.
Constraints on package "caching-compiler":
* caching-compiler@~2.0.0-alpha300.18 <- top level
* caching-compiler@2.0.0-alpha300.17 <- caching-html-compiler 2.0.0-alpha300.17 <- static-html 1.3.3-alpha300.18
* caching-compiler@2.0.0-alpha300.17 <- coffeescript 2.7.0
* caching-compiler@1.2.2 <- universe:i18n 2.1.0
Tested with METEOR@3.0-beta.6
```

Following this PR : https://github.com/vazco/meteor-universe-i18n/pull/185 I have proposed a new version with several possible versions of caching-compiler : 1.2.2 (original one), 2.0.0-beta300.6 (one actually published as of today), 2.0.0 (to be published when v3 goes live I guess)