### PR TITLE
Fix issue on meteor 3.0 on patch publish and perserve env variable

### DIFF
--- a/source/server.ts
+++ b/source/server.ts
@@ -220,16 +220,16 @@ Meteor.onConnection(connection => {
 
 function patchPublish(publish: typeof Meteor.publish) {
   return function (this: typeof Meteor, name, func, ...args) {
-    return publish.call(
-      this,
-      name,
-      function (...args) {
-        return _publishConnectionId.withValue(this?.connection?.id, () =>
-          func.apply(this, args),
-        );
-      },
-      ...args,
-    );
+    return _publishConnectionId.withValue(this?.connection?.id, () => {
+      return publish.call(
+        this,
+        name,
+        function (...args) {
+          return func.apply(this, args);
+        },
+        ...args,
+      );
+    });
   } as typeof Meteor.publish;
 }
 


### PR DESCRIPTION
This PR refers to the issue https://github.com/vazco/meteor-universe-i18n/issues/190 and refered to the core at https://github.com/meteor/meteor/issues/13258.

The fix involves using `EnvironmentVariable.withValue` before calling `publish.call`. This ensures the context is preserved and spread properly throughout the entire flow of an altered publication. This was a breaking change on Meteor 3 added on this change, https://github.com/meteor/meteor/pull/13063.

I tried running the test suite to check if anything else is broken that might need deeper investigation on the meteor core level or if this fix is sufficient for all publication alterations as the one on this repository. I also wanted to add a regression test, but the suite isn't passing any tests. What am I doing wrong?